### PR TITLE
ios-study-65:Create GuessColor game

### DIFF
--- a/GameColorSimilarity/GameColorSimilarity.xcodeproj/project.pbxproj
+++ b/GameColorSimilarity/GameColorSimilarity.xcodeproj/project.pbxproj
@@ -1,0 +1,344 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		84A82EBD2886A43800CE5B36 /* GameColorSimilarityApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A82EBC2886A43800CE5B36 /* GameColorSimilarityApp.swift */; };
+		84A82EBF2886A43800CE5B36 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A82EBE2886A43800CE5B36 /* ContentView.swift */; };
+		84A82EC12886A43C00CE5B36 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84A82EC02886A43C00CE5B36 /* Assets.xcassets */; };
+		84A82EC42886A43C00CE5B36 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84A82EC32886A43C00CE5B36 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		84A82EB92886A43800CE5B36 /* GameColorSimilarity.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GameColorSimilarity.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		84A82EBC2886A43800CE5B36 /* GameColorSimilarityApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameColorSimilarityApp.swift; sourceTree = "<group>"; };
+		84A82EBE2886A43800CE5B36 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		84A82EC02886A43C00CE5B36 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		84A82EC32886A43C00CE5B36 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		84A82EB62886A43800CE5B36 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		84A82EB02886A43800CE5B36 = {
+			isa = PBXGroup;
+			children = (
+				84A82EBB2886A43800CE5B36 /* GameColorSimilarity */,
+				84A82EBA2886A43800CE5B36 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		84A82EBA2886A43800CE5B36 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				84A82EB92886A43800CE5B36 /* GameColorSimilarity.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		84A82EBB2886A43800CE5B36 /* GameColorSimilarity */ = {
+			isa = PBXGroup;
+			children = (
+				84A82EBC2886A43800CE5B36 /* GameColorSimilarityApp.swift */,
+				84A82EBE2886A43800CE5B36 /* ContentView.swift */,
+				84A82EC02886A43C00CE5B36 /* Assets.xcassets */,
+				84A82EC22886A43C00CE5B36 /* Preview Content */,
+			);
+			path = GameColorSimilarity;
+			sourceTree = "<group>";
+		};
+		84A82EC22886A43C00CE5B36 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				84A82EC32886A43C00CE5B36 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		84A82EB82886A43800CE5B36 /* GameColorSimilarity */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 84A82EC72886A43C00CE5B36 /* Build configuration list for PBXNativeTarget "GameColorSimilarity" */;
+			buildPhases = (
+				84A82EB52886A43800CE5B36 /* Sources */,
+				84A82EB62886A43800CE5B36 /* Frameworks */,
+				84A82EB72886A43800CE5B36 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GameColorSimilarity;
+			productName = GameColorSimilarity;
+			productReference = 84A82EB92886A43800CE5B36 /* GameColorSimilarity.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		84A82EB12886A43800CE5B36 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1340;
+				LastUpgradeCheck = 1340;
+				TargetAttributes = {
+					84A82EB82886A43800CE5B36 = {
+						CreatedOnToolsVersion = 13.4.1;
+					};
+				};
+			};
+			buildConfigurationList = 84A82EB42886A43800CE5B36 /* Build configuration list for PBXProject "GameColorSimilarity" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 84A82EB02886A43800CE5B36;
+			productRefGroup = 84A82EBA2886A43800CE5B36 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				84A82EB82886A43800CE5B36 /* GameColorSimilarity */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		84A82EB72886A43800CE5B36 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84A82EC42886A43C00CE5B36 /* Preview Assets.xcassets in Resources */,
+				84A82EC12886A43C00CE5B36 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		84A82EB52886A43800CE5B36 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				84A82EBF2886A43800CE5B36 /* ContentView.swift in Sources */,
+				84A82EBD2886A43800CE5B36 /* GameColorSimilarityApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		84A82EC52886A43C00CE5B36 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		84A82EC62886A43C00CE5B36 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		84A82EC82886A43C00CE5B36 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"GameColorSimilarity/Preview Content\"";
+				DEVELOPMENT_TEAM = 6WNZ6H5K49;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "Oleksandr-Syurpita.GameColorSimilarity";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		84A82EC92886A43C00CE5B36 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"GameColorSimilarity/Preview Content\"";
+				DEVELOPMENT_TEAM = 6WNZ6H5K49;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "Oleksandr-Syurpita.GameColorSimilarity";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		84A82EB42886A43800CE5B36 /* Build configuration list for PBXProject "GameColorSimilarity" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				84A82EC52886A43C00CE5B36 /* Debug */,
+				84A82EC62886A43C00CE5B36 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		84A82EC72886A43C00CE5B36 /* Build configuration list for PBXNativeTarget "GameColorSimilarity" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				84A82EC82886A43C00CE5B36 /* Debug */,
+				84A82EC92886A43C00CE5B36 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 84A82EB12886A43800CE5B36 /* Project object */;
+}

--- a/GameColorSimilarity/GameColorSimilarity.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/GameColorSimilarity/GameColorSimilarity.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/GameColorSimilarity/GameColorSimilarity.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/GameColorSimilarity/GameColorSimilarity.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/GameColorSimilarity/GameColorSimilarity/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/GameColorSimilarity/GameColorSimilarity/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GameColorSimilarity/GameColorSimilarity/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/GameColorSimilarity/GameColorSimilarity/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GameColorSimilarity/GameColorSimilarity/Assets.xcassets/Contents.json
+++ b/GameColorSimilarity/GameColorSimilarity/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/GameColorSimilarity/GameColorSimilarity/ContentView.swift
+++ b/GameColorSimilarity/GameColorSimilarity/ContentView.swift
@@ -1,0 +1,85 @@
+//
+//  ContentView.swift
+//  GameColorSimilarity
+//
+//  Created by admin on 19.07.2022.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    
+    @State var RColor: Double = 0
+    @State var GColor: Double = 0
+    @State var BColor: Double = 0
+    @State var RandomColor = Color.black
+    @State var RandomRColor: Double = 0
+    @State var RandomGColor: Double = 0
+    @State var RandomBColor: Double = 0
+    @State private var alertShow = false
+    
+    var body: some View {
+        ZStack {
+            VStack {
+                HStack {
+                    HStack {
+                        Text("")
+                    }
+                    .frame(width: 100, height: 200)
+                    .background(RandomColor)
+                    HStack {
+                        Text("")
+                    }
+                    .frame(width: 100, height: 200)
+                    .background(Color(red: RColor , green: GColor , blue: BColor))
+                }
+                Text("Red Color \(Int(RandomRColor))\n Green Color \(Int(RandomGColor)) \n Blue Color \(Int(RandomBColor)) \n")
+                
+                Button(action: { newColor() }) {
+                    Text("Tap me for generate new color")
+                }
+                Slider(value: $RColor)
+                    .frame(width: 255, height: 40)
+                Slider(value: $GColor)
+                    .frame(width: 255, height: 40)
+                Slider(value: $BColor)
+                    .frame(width: 255, height: 40)
+                
+                Text("Red Color \(Int(RColor * 255 ))\n Green Color \(Int(GColor * 255 ))\n Blue Color \(Int(BColor * 255))\n")
+                Button(action: { self.alertShow = true }) {
+                    Text("Hit me")
+                }.alert(isPresented: $alertShow) {
+                    Alert(title: Text("Your Score"),
+                          message: Text(String(computeScore())))
+                }
+            }
+        }
+    }
+    func newColor() {
+        let RColorrandom = Double.random(in: 0...255)
+        let GColorrandom = Double.random(in: 0...255)
+        let BColorrandom = Double.random(in: 0...255)
+        let randomColor = Color(red: RColorrandom / 255, green: GColorrandom / 255, blue: BColorrandom / 255)
+        self.RandomColor = randomColor
+        self.RandomRColor = RColorrandom
+        self.RandomGColor = GColorrandom
+        self.RandomBColor = BColorrandom
+    }
+    func computeScore() -> Int {
+        let temp =  Double(round(100 * RandomRColor)/100) / 255
+        let temp2 = Double(round(100 * RandomGColor)/100) / 255
+        let temp3 = Double(round(100 * RandomBColor)/100) / 255
+        let RFinal = Double(round(100 * RColor)/100) - temp
+        let GFinal = Double(round(100 * GColor)/100) - temp2
+        let BFinal = Double(round(100 * BColor)/100) - temp3
+        let diff = sqrt(
+            (RFinal * RFinal + GFinal * GFinal + BFinal * BFinal) / 3.0)
+        return lround((1.0 - diff) * 100.0)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/GameColorSimilarity/GameColorSimilarity/GameColorSimilarityApp.swift
+++ b/GameColorSimilarity/GameColorSimilarity/GameColorSimilarityApp.swift
@@ -1,0 +1,17 @@
+//
+//  GameColorSimilarityApp.swift
+//  GameColorSimilarity
+//
+//  Created by admin on 19.07.2022.
+//
+
+import SwiftUI
+
+@main
+struct GameColorSimilarityApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/GameColorSimilarity/GameColorSimilarity/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/GameColorSimilarity/GameColorSimilarity/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## What's New

1. Create GuessColor game

- Create two rectangles (first will contain randomly generated colour, second will be configured by sliders)
- Add three sliders (RGB colours)
- Add button that will check on tapping how close user is to right RGB values and show alert with score

## Issue

- ios-study-65

https://user-images.githubusercontent.com/80582349/179792683-25db50aa-8c8a-40d9-8772-2dddd193780f.mov



## Video